### PR TITLE
Update regex check for Windows Server version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
   ansible.builtin.assert:
     that:
       - ansible_os_family == 'Windows'
-      - ansible_distribution | regex_search('(Microsoft Windows Server 2025)')
+      - ansible_distribution is regex('Microsoft Windows Server 2025')
     success_msg: "{{ ansible_distribution }} {{ ansible_distribution_major_version }} is the detected operating system."
     fail_msg: "This role can only be run against Windows Server 2025 Editions. {{ ansible_distribution }} {{ ansible_distribution_major_version }} is not supported."
 


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Change ansible_distribution | regex_search('(Microsoft Windows Server 2025)')
To ansible_distribution is regex('Microsoft Windows Server 2025')

**How has this been tested?:**
Use playbook on empty Windows 2025 vm

