### PR TITLE
Fix: Change action from 'set' to 'add' for rule 2.2.27 RDP deny policy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -846,10 +846,10 @@ win25cis_ldap_client_integrity: 1
 # Log\Microsoft\Windows\NTLM). Configuring this setting to Deny All also conforms to the benchmark.
 # The recommended state for this setting is: Audit All.
 # Note: Possible Valid Settings
-# 1 - Deny All
-# 2 - Audit All
-# Default: 2
-win25cis_restrict_sending_ntlm_traffic: 2
+# 1 - Audit All
+# 2 - Deny All
+# Default: 1
+win25cis_restrict_sending_ntlm_traffic: 1
 
 # 2.3.17.2
 # win25cis_consent_prompt_behavior_admin is the policy setting controls the behavior of the elevation prompt for administrators.

--- a/tasks/ansible_hardening/section02.yml
+++ b/tasks/ansible_hardening/section02.yml
@@ -849,7 +849,7 @@
     users:
       - Guests
       - Local Account
-    action: set
+    action: add
 
 - name: "2.2.28 | PATCH | Ensure Enable computer and user accounts to be trusted for delegation is set to Administrators DC only | Domain Controller"
   when:


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
- Updated section02.yml rule 2.2.27 to use 'add' action instead of 'set'
- This ensures Local Account is added to the deny list rather than replacing existing entries

**Issue Fixes:**
prevent overwrite of custom deny users/groups

**Enhancements:**


**How has this been tested?:**
N/A

