### PR TITLE
Fix: correct the default value and definitions of win25cis_restrict_sending_ntlm_traffic

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -846,10 +846,10 @@ win25cis_ldap_client_integrity: 1
 # Log\Microsoft\Windows\NTLM). Configuring this setting to Deny All also conforms to the benchmark.
 # The recommended state for this setting is: Audit All.
 # Note: Possible Valid Settings
-# 1 - Deny All
-# 2 - Audit All
-# Default: 2
-win25cis_restrict_sending_ntlm_traffic: 2
+# 1 - Audit All
+# 2 - Deny All
+# Default: 1
+win25cis_restrict_sending_ntlm_traffic: 1
 
 # 2.3.17.2
 # win25cis_consent_prompt_behavior_admin is the policy setting controls the behavior of the elevation prompt for administrators.


### PR DESCRIPTION
**Overall Review of Changes:**
- Swaps the definitions of values for win25cis_restrict_sending_ntlm_traffic in comments
- Updates the default to be the correct value for `Audit All` which is the recommended default value

**Issue Fixes:**
Fixes: Issue #2 (defaults/main.yml has wrong values for win25cis_restrict_sending_ntlm_traffic)

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Tested 2 image runs:
- 1 with `win25cis_restrict_sending_ntlm_traffic: 1`
- 1 with `win25cis_restrict_sending_ntlm_traffic: 2` 
- Verified the behavior matches correctly

